### PR TITLE
Resolve bug #265 and introduce pixelcrop

### DIFF
--- a/plugins/houdini/mantrafilter.py
+++ b/plugins/houdini/mantrafilter.py
@@ -76,10 +76,16 @@ def filterPlane():
 # A callback to change image crop and write down main image filename:
 def filterCamera():
 	if tilerender:
+		resolution = mantra.property('image:resolution')
 		oldcrop = mantra.property('image:crop')
+		if oldcrop[0]>oldcrop[1]: # no crop in ifd file
+			oldcrop = [0, 1, 0, 1]
 		newcrop = [max(tilecrop[0], oldcrop[0]), min(tilecrop[1], oldcrop[1]),
-				   max(tilecrop[2], oldcrop[2]), min(tilecrop[3], oldcrop[3])]
-		mantra.setproperty('image:crop', newcrop)
+			   max(tilecrop[2], oldcrop[2]), min(tilecrop[3], oldcrop[3])]
+		# convert to pixels
+		newpixelcrop = [int(resolution[0] * newcrop[0]), int(resolution[0] * newcrop[1])-1,
+				int(resolution[1] * newcrop[2]), int(resolution[1] * newcrop[3])-1]
+		mantra.setproperty('image:pixelcrop', newpixelcrop)
 
 
 def filterQuit():


### PR DESCRIPTION
Since H15.5, SideFX changed image:crop default value.
From SESI:

> image:crop default value was changed when we added support for overscan and generic data windows in images.
> The mantra default crop window is to have no crop window (i.e. an invalid crop window). This allows mantra to know whether a bounding box was actually specified in the IFD or not.
> 
> As a note, the code in mantra looks something like:
> 
> ```
> crop = getProperty("crop");
> pcrop = getProperty("pixelcrop");
> screen.makeInvalid();
> if (pcrop.isValid())
>      screen = pcrop;
> if (crop.isValid())
> {
>      crop.convertToPixels();
>      if (screen.isValid())
>          screen.intersect(crop);
>      else
>          screen = crop;
> }
> if (!screen.isValid())
>      screen = [0, xres-1, 0, yres-1]
> ```

This commit resolve the bug #265 and introduce a crop with pixelcrop, a crop with pixel values.
image:pixelcrop property exists at least since H12.0.
